### PR TITLE
修正Firefox不能使用的BUG，增強菜單按鈕對比度

### DIFF
--- a/src/components/vm-markdown-button.vue
+++ b/src/components/vm-markdown-button.vue
@@ -20,6 +20,7 @@
     display: flex;
     justify-content: center;
     color: inherit;
+    transform: scale(1.3);
     &:first-child{
       margin-left: 0;
     }

--- a/src/components/vm-markdown.vue
+++ b/src/components/vm-markdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="vm-markdown" :style="{width: width, height:height}">
-    <VmMarkdownMenu :bgMenu="themeValue.bgMenu" 
+    <VmMarkdownMenu :bgMenu="themeValue.bgMenu"
                     :menuBorder="themeValue.menuBorder"
                     :menuColor="themeValue.menuColor"
                     :hoverColor="themeValue.hoverColor"
@@ -8,14 +8,14 @@
                   >
     </VmMarkdownMenu>
     <div class="content">
-      <div class="vm-markdown-edit" :style="{backgroundColor: themeValue.bgLeft}">
+      <div class="vm-markdown-edit" contenteditable="true" :style="{backgroundColor: themeValue.bgLeft}">
         <textarea v-focus class="content-markdown" v-model="markdString"></textarea>
       </div>
       <div class="vm-markdown-html" v-html="htmlString" :style="{backgroundColor: themeValue.bgRight}">
-        
+
       </div>
     </div>
-    
+
   </div>
 </template>
 <style lang="scss">
@@ -38,8 +38,8 @@
       font-size: 16px;
       border: 1px solid #eeeff1;
       border-top: none;
-      .vm-markdown-edit, .render{       
-        height: 100%;    
+      .vm-markdown-edit, .render{
+        height: 100%;
       }
       .vm-markdown-edit{
         width: 50%;
@@ -171,12 +171,12 @@ export default {
   methods: {
     layout: function (event) {
       let VmMarkdown = document.querySelector('.vm-markdown')
-      let VmMarkdownEdit = document.querySelector('.vm-markdown-edit')    
+      let VmMarkdownEdit = document.querySelector('.vm-markdown-edit')
       function classHas(str){
         return event.target.classList.contains(str)
       }
       if(classHas('icon-layout-zoom')){
-        
+
         if (VmMarkdown.style.position === 'fixed') {
           VmMarkdown.style = 'width:' + this.width + ';' +
                              'height:' + this.height + ';'
@@ -187,7 +187,7 @@ export default {
           VmMarkdown.style.margin = '0'
           VmMarkdown.style.width = '100%'
           VmMarkdown.style.height = '100%'
-        }   
+        }
       }else if (classHas('icon-layout-left')) {
         VmMarkdownEdit.style.width = '0'
       }else if (classHas('icon-layout-right')) {

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,6 +1,6 @@
 let theme = {
 	default: {
-      menuColor: '#6d96c1',
+      menuColor: '#ffffff',
       menuBorder: '1px solid #35495e',
       hoverColor: '#88bcf1',
       bgMenu: '#35495e',
@@ -8,7 +8,7 @@ let theme = {
       bgRight: '#ffffff'
     },
     green: {
-      menuColor: '#50e2a1',
+      menuColor: '#ffffff',
       menuBorder: '1px solid #41b883',
       hoverColor: '#5affb6',
       bgMenu: '#41b883',
@@ -16,7 +16,7 @@ let theme = {
       bgRight: '#ffffff'
     },
 	gray: {
-      menuColor: '#858585',
+      menuColor: '#27292C',
       menuBorder: '1px solid #eeeff1',
       hoverColor: '#232323',
       bgMenu: '#fafbfc',
@@ -24,7 +24,7 @@ let theme = {
       bgRight: '#fff'
     },
     dark: {
-      menuColor: '#858585',
+      menuColor: '#ffffff',
       menuBorder: '1px solid #27292c',
       hoverColor: '#09bb07',
       bgMenu: '#27292c',


### PR DESCRIPTION
在Firefox上，Div （vm-markdown-edit）必須加上 contenteditable="true" 才能使用execCommand進行修改。
同時也加強了菜單按鈕的對比度